### PR TITLE
Fix: captureAndShare uses path and pixelRatio

### DIFF
--- a/lib/take_screenshot.dart
+++ b/lib/take_screenshot.dart
@@ -79,7 +79,7 @@ class TakeScreenshotController {
     String? text,
   }) async {
     try {
-      final file = await captureAsFile();
+      final file = await captureAsFile(path: path, pixelRatio: pixelRatio);
       await Share.shareFiles([file.path],
           mimeTypes: mimeTypes,
           sharePositionOrigin: sharePositionOrigin,


### PR DESCRIPTION
`captureAndShare` does not use parameter `path` or `pixelRatio`, fix now